### PR TITLE
attempt to test fix for issue UD-1213

### DIFF
--- a/hidef/hidef_finder.py
+++ b/hidef/hidef_finder.py
@@ -178,7 +178,7 @@ def run_alg(G, alg, gamma=1.0):
         partition = louvain.find_partition(G, partition_type, resolution_parameter=gamma)
     elif alg == 'leiden':
         partition_type = leidenalg.RBConfigurationVertexPartition
-        partition = leidenalg.RBConfigurationVertexPartition(G, partition_type, resolution_parameter=gamma)
+        partition = leidenalg.find_partition(G, partition_type, resolution_parameter=gamma)
     # partition = sorted(partition, key=len, reverse=True)
     return partition
 


### PR DESCRIPTION
Fixed bug where using --alg leiden would fail with this error:

```Bash
Traceback (most recent call last):
  File "/opt/conda/bin/hidef_finder.py", line 575, in <module>
    alg=args.alg
  File "/opt/conda/bin/hidef_finder.py", line 322, in run
    minres_partition = run_alg(G, alg, minres)
  File "/opt/conda/bin/hidef_finder.py", line 191, in run_alg
    partition = leidenalg.RBConfigurationVertexPartition(G, partition_type, resolution_parameter=gamma)
  File "/opt/conda/lib/python3.7/site-packages/leidenalg/VertexPartition.py", line 786, in __init__
    initial_membership = list(initial_membership)
TypeError: 'type' object is not iterable
```
Basically there was a typo. 